### PR TITLE
Added assertion conditions validation and signature validation to the Passive STS Federated Authenticator.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.passive.sts/src/main/java/org/wso2/carbon/identity/application/authenticator/passive/sts/PassiveSTSAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.passive.sts/src/main/java/org/wso2/carbon/identity/application/authenticator/passive/sts/PassiveSTSAuthenticator.java
@@ -36,8 +36,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 public class PassiveSTSAuthenticator extends AbstractApplicationAuthenticator implements FederatedApplicationAuthenticator {

--- a/components/org.wso2.carbon.identity.application.authenticator.passive.sts/src/main/java/org/wso2/carbon/identity/application/authenticator/passive/sts/PassiveSTSAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.passive.sts/src/main/java/org/wso2/carbon/identity/application/authenticator/passive/sts/PassiveSTSAuthenticator.java
@@ -36,6 +36,8 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 public class PassiveSTSAuthenticator extends AbstractApplicationAuthenticator implements FederatedApplicationAuthenticator {


### PR DESCRIPTION
This PR adds some SAML token validations to the Passive STS Federated Authenticator.

As per the token profile specification [1], SAML assertions must be validated with regard to the corresponding SAML specification. But it does not specifically say which are mandatory.

Thus, this PR adds Assertion validity period verification against 'Not Before' and 'Not On Or After' conditions if they are present as these conditions are optional in the core spec.
Adds Assertion Signature validation. By default Assertion Signature validation is enforced, but that can be disabled from the respective IdP Configuration. 
Adds Audience Restriction validation. By default Audience Restriction validation is enforced, but that can be disabled from the respective IdP Configuration.
Also validates SAML schema and restricts multiple Assertion elements.

[1] http://docs.oasis-open.org/wss-m/wss/v1.1.1/os/wss-SAMLTokenProfile-v1.1.1-os.html#_Toc307397294
