### PR TITLE
Fix building claim mapping from user attributes in the response

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.passive.sts/src/main/java/org/wso2/carbon/identity/application/authenticator/passive/sts/manager/PassiveSTSManager.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.passive.sts/src/main/java/org/wso2/carbon/identity/application/authenticator/passive/sts/manager/PassiveSTSManager.java
@@ -312,9 +312,16 @@ public class PassiveSTSManager {
         Map<ClaimMapping, String> results = new HashMap<ClaimMapping, String>();
         for (Map.Entry<String, String> entry : userAttributes.entrySet()) {
             ClaimMapping claimMapping = new ClaimMapping();
-            Claim claim = new Claim();
-            claim.setClaimUri(entry.getKey());
-            claimMapping.setRemoteClaim(claim);
+
+            Claim localClaim = new Claim();
+            localClaim.setClaimUri(entry.getKey());
+
+            Claim remoteClaim = new Claim();
+            remoteClaim.setClaimUri(entry.getKey());
+
+            claimMapping.setLocalClaim(localClaim);
+            claimMapping.setRemoteClaim(remoteClaim);
+
             results.put(claimMapping, entry.getValue());
         }
         return results;


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes https://github.com/wso2/product-is/issues/4715
- When the user attributes are retrieved from the response, a claim mapping for each attribute will be stored as authenticated user attributes.
- During building a claim mapping from a user attribute, both remote and local claim URIs are needed to be set with the attribute name from the response.

### When should this PR be merged

- ASAP

#### Documentation

- N/A
