### PR TITLE
Changes for OpenSAML3 migration

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.passive.sts/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.passive.sts/pom.xml
@@ -130,7 +130,7 @@
                             org.wso2.carbon.identity.application.common.util;
                             version="${carbon.identity.package.import.version.range}",
 
-                            org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}"
+                            org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}",
 
                             org.wso2.carbon.ui; version="${carbon.kernel.package.import.version.range}",
 

--- a/components/org.wso2.carbon.identity.application.authenticator.passive.sts/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.passive.sts/pom.xml
@@ -81,6 +81,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.saml.common</groupId>
+            <artifactId>org.wso2.carbon.identity.saml.common.util</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.orbit.org.opensaml</groupId>
             <artifactId>opensaml</artifactId>
         </dependency>
@@ -111,6 +115,7 @@
                             org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
                             org.apache.xerces.util; resolution:=optional,
 
+                            org.wso2.carbon.identity.saml.common.util.*; version="${saml.common.util.version.range}",
                             org.opensaml.*; version="${opensaml2.wso2.osgi.version.range}",
 
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.application.authenticator.passive.sts/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.passive.sts/pom.xml
@@ -43,6 +43,16 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.base</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.opensaml</groupId>
+                    <artifactId>opensaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.opensaml</groupId>
+                    <artifactId>opensaml1</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
@@ -59,6 +69,16 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.opensaml</groupId>
+                    <artifactId>opensaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.opensaml</groupId>
+                    <artifactId>opensaml1</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.org.opensaml</groupId>
@@ -104,6 +124,8 @@
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.common.util;
                             version="${carbon.identity.package.import.version.range}",
+
+                            org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}"
 
                             org.wso2.carbon.ui; version="${carbon.kernel.package.import.version.range}",
 

--- a/components/org.wso2.carbon.identity.application.authenticator.passive.sts/src/main/java/org/wso2/carbon/identity/application/authenticator/passive/sts/manager/PassiveSTSManager.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.passive.sts/src/main/java/org/wso2/carbon/identity/application/authenticator/passive/sts/manager/PassiveSTSManager.java
@@ -54,7 +54,7 @@ import org.wso2.carbon.identity.application.common.model.Claim;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
-import org.wso2.carbon.identity.core.util.SAMLInitializer;
+import org.wso2.carbon.identity.saml.common.util.SAMLInitializer;
 import org.xml.sax.SAXException;
 
 import java.io.ByteArrayInputStream;

--- a/components/org.wso2.carbon.identity.application.authenticator.passive.sts/src/main/java/org/wso2/carbon/identity/application/authenticator/passive/sts/manager/PassiveSTSManager.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.passive.sts/src/main/java/org/wso2/carbon/identity/application/authenticator/passive/sts/manager/PassiveSTSManager.java
@@ -22,24 +22,23 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.joda.time.DateTime;
-import org.opensaml.Configuration;
-import org.opensaml.DefaultBootstrap;
-import org.opensaml.common.SignableSAMLObject;
-import org.opensaml.common.xml.SAMLConstants;
-import org.opensaml.saml1.core.Attribute;
-import org.opensaml.saml1.core.AttributeStatement;
-import org.opensaml.saml1.core.NameIdentifier;
-import org.opensaml.saml1.core.Subject;
-import org.opensaml.security.SAMLSignatureProfileValidator;
-import org.opensaml.xml.ConfigurationException;
-import org.opensaml.xml.XMLObject;
-import org.opensaml.xml.io.Unmarshaller;
-import org.opensaml.xml.io.UnmarshallerFactory;
-import org.opensaml.xml.io.UnmarshallingException;
-import org.opensaml.xml.security.x509.X509Credential;
-import org.opensaml.xml.signature.Signature;
-import org.opensaml.xml.signature.SignatureValidator;
-import org.opensaml.xml.validation.ValidationException;
+import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
+import org.opensaml.saml.common.SignableSAMLObject;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml1.core.Attribute;
+import org.opensaml.saml.saml1.core.AttributeStatement;
+import org.opensaml.saml.saml1.core.NameIdentifier;
+import org.opensaml.saml.saml1.core.Subject;
+import org.opensaml.saml.security.impl.SAMLSignatureProfileValidator;
+import org.opensaml.core.config.InitializationException;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.core.xml.io.Unmarshaller;
+import org.opensaml.core.xml.io.UnmarshallerFactory;
+import org.opensaml.core.xml.io.UnmarshallingException;
+import org.opensaml.security.x509.X509Credential;
+import org.opensaml.xmlsec.signature.Signature;
+import org.opensaml.xmlsec.signature.support.SignatureValidator;
+import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -55,6 +54,7 @@ import org.wso2.carbon.identity.application.common.model.Claim;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.core.util.SAMLInitializer;
 import org.xml.sax.SAXException;
 
 import java.io.ByteArrayInputStream;
@@ -100,10 +100,10 @@ public class PassiveSTSManager {
         /* Initializing the OpenSAML library */
         if (!bootStrapped) {
             try {
-                DefaultBootstrap.bootstrap();
+                SAMLInitializer.doBootstrap();
                 bootStrapped = true;
-            } catch (ConfigurationException e) {
-                log.error("Error in bootstrapping the OpenSAML2 library", e);
+            } catch (InitializationException e) {
+                log.error("Error in bootstrapping the OpenSAML3 library", e);
             }
         }
     }
@@ -136,7 +136,7 @@ public class PassiveSTSManager {
 
     /**
      * @param request
-     * @param externalIdPConfig
+     * @param context
      * @throws PassiveSTSException
      */
     public void processResponse(HttpServletRequest request, AuthenticationContext context) throws PassiveSTSException {
@@ -162,8 +162,8 @@ public class PassiveSTSManager {
         String subject = null;
         Map<String, String> attributeMap = new HashMap<String, String>();
 
-        if (xmlObject instanceof org.opensaml.saml1.core.Assertion) {
-            org.opensaml.saml1.core.Assertion assertion = (org.opensaml.saml1.core.Assertion) xmlObject;
+        if (xmlObject instanceof org.opensaml.saml.saml1.core.Assertion) {
+            org.opensaml.saml.saml1.core.Assertion assertion = (org.opensaml.saml.saml1.core.Assertion) xmlObject;
             if (CollectionUtils.isNotEmpty(assertion.getAuthenticationStatements())) {
                 Subject subjectElem = assertion.getAuthenticationStatements().get(0).getSubject();
 
@@ -193,17 +193,17 @@ public class PassiveSTSManager {
                     }
                 }
             }
-        } else if (xmlObject instanceof org.opensaml.saml2.core.Assertion) {
+        } else if (xmlObject instanceof org.opensaml.saml.saml2.core.Assertion) {
 
-            org.opensaml.saml2.core.Assertion assertion = (org.opensaml.saml2.core.Assertion) xmlObject;
+            org.opensaml.saml.saml2.core.Assertion assertion = (org.opensaml.saml.saml2.core.Assertion) xmlObject;
 
             if (assertion.getSubject() != null && assertion.getSubject().getNameID() != null) {
                 subject = assertion.getSubject().getNameID().getValue();
             }
 
-            for (org.opensaml.saml2.core.AttributeStatement statement : assertion.getAttributeStatements()) {
-                List<org.opensaml.saml2.core.Attribute> attributes = statement.getAttributes();
-                for (org.opensaml.saml2.core.Attribute attribute : attributes) {
+            for (org.opensaml.saml.saml2.core.AttributeStatement statement : assertion.getAttributeStatements()) {
+                List<org.opensaml.saml.saml2.core.Attribute> attributes = statement.getAttributes();
+                for (org.opensaml.saml.saml2.core.Attribute attribute : attributes) {
                     String attributeUri = attribute.getName();
                     List<XMLObject> xmlObjects = attribute.getAttributeValues();
                     for (XMLObject object : xmlObjects) {
@@ -289,7 +289,7 @@ public class PassiveSTSManager {
             }
 
             Element node = (Element) nodeList.item(0).getFirstChild();
-            UnmarshallerFactory unmarshallerFactory = Configuration.getUnmarshallerFactory();
+            UnmarshallerFactory unmarshallerFactory = XMLObjectProviderRegistrySupport.getUnmarshallerFactory();
             Unmarshaller unmarshaller = unmarshallerFactory.getUnmarshaller(node);
             return unmarshaller.unmarshall(node);
         } catch (ParserConfigurationException e) {
@@ -343,14 +343,14 @@ public class PassiveSTSManager {
         DateTime validFrom = null;
         DateTime validTill = null;
 
-        if (xmlObject instanceof org.opensaml.saml1.core.Assertion) {
-            org.opensaml.saml1.core.Assertion saml1Assertion = (org.opensaml.saml1.core.Assertion) xmlObject;
+        if (xmlObject instanceof org.opensaml.saml.saml1.core.Assertion) {
+            org.opensaml.saml.saml1.core.Assertion saml1Assertion = (org.opensaml.saml.saml1.core.Assertion) xmlObject;
             if (saml1Assertion.getConditions() != null) {
                 validFrom = saml1Assertion.getConditions().getNotBefore();
                 validTill = saml1Assertion.getConditions().getNotOnOrAfter();
             }
-        } else if (xmlObject instanceof org.opensaml.saml2.core.Assertion) {
-            org.opensaml.saml2.core.Assertion saml2Assertion = (org.opensaml.saml2.core.Assertion) xmlObject;
+        } else if (xmlObject instanceof org.opensaml.saml.saml2.core.Assertion) {
+            org.opensaml.saml.saml2.core.Assertion saml2Assertion = (org.opensaml.saml.saml2.core.Assertion) xmlObject;
             if (saml2Assertion.getConditions() != null) {
                 validFrom = saml2Assertion.getConditions().getNotBefore();
                 validTill = saml2Assertion.getConditions().getNotOnOrAfter();
@@ -399,10 +399,10 @@ public class PassiveSTSManager {
                 log.debug("Validating SAML Assertion's Audience Restriction Condition.");
             }
 
-            if (xmlObject instanceof org.opensaml.saml1.core.Assertion) {
-                validateAudienceRestriction(context, (org.opensaml.saml1.core.Assertion) xmlObject);
-            } else if (xmlObject instanceof org.opensaml.saml2.core.Assertion) {
-                validateAudienceRestriction(context, (org.opensaml.saml2.core.Assertion) xmlObject);
+            if (xmlObject instanceof org.opensaml.saml.saml1.core.Assertion) {
+                validateAudienceRestriction(context, (org.opensaml.saml.saml1.core.Assertion) xmlObject);
+            } else if (xmlObject instanceof org.opensaml.saml.saml2.core.Assertion) {
+                validateAudienceRestriction(context, (org.opensaml.saml.saml2.core.Assertion) xmlObject);
             } else {
                 throw new PassiveSTSException(
                         "Unknown Security Token. Can process only SAML 1.0 and SAML 2.0 Assertions");
@@ -418,11 +418,11 @@ public class PassiveSTSManager {
      * @throws PassiveSTSException
      */
     private void validateAudienceRestriction(AuthenticationContext context,
-                                             org.opensaml.saml1.core.Assertion saml1Assertion)
+                                             org.opensaml.saml.saml1.core.Assertion saml1Assertion)
             throws PassiveSTSException {
 
         if (saml1Assertion.getConditions() != null) {
-            List<org.opensaml.saml1.core.AudienceRestrictionCondition> audienceRestrictions =
+            List<org.opensaml.saml.saml1.core.AudienceRestrictionCondition> audienceRestrictions =
                     saml1Assertion.getConditions().getAudienceRestrictionConditions();
             if (audienceRestrictions != null && !audienceRestrictions.isEmpty()) {
                 /**
@@ -439,10 +439,10 @@ public class PassiveSTSManager {
                                                   " determine intended audience.");
                 }
 
-                for (org.opensaml.saml1.core.AudienceRestrictionCondition audienceRestriction : audienceRestrictions) {
+                for (org.opensaml.saml.saml1.core.AudienceRestrictionCondition audienceRestriction : audienceRestrictions) {
                     if (CollectionUtils.isNotEmpty(audienceRestriction.getAudiences())) {
                         boolean audienceFound = false;
-                        for (org.opensaml.saml1.core.Audience audience : audienceRestriction.getAudiences()) {
+                        for (org.opensaml.saml.saml1.core.Audience audience : audienceRestriction.getAudiences()) {
                             if (intendedAudience.equals(audience.getUri())) {
                                 audienceFound = true;
                                 break;
@@ -470,11 +470,11 @@ public class PassiveSTSManager {
      * @throws PassiveSTSException
      */
     private void validateAudienceRestriction(AuthenticationContext context,
-                                             org.opensaml.saml2.core.Assertion saml2Assertion)
+                                             org.opensaml.saml.saml2.core.Assertion saml2Assertion)
             throws PassiveSTSException {
 
         if (saml2Assertion.getConditions() != null) {
-            List<org.opensaml.saml2.core.AudienceRestriction> audienceRestrictions =
+            List<org.opensaml.saml.saml2.core.AudienceRestriction> audienceRestrictions =
                     saml2Assertion.getConditions().getAudienceRestrictions();
             if (audienceRestrictions != null && !audienceRestrictions.isEmpty()) {
                 /**
@@ -491,10 +491,10 @@ public class PassiveSTSManager {
                                                   " determine intended audience.");
                 }
 
-                for (org.opensaml.saml2.core.AudienceRestriction audienceRestriction : audienceRestrictions) {
+                for (org.opensaml.saml.saml2.core.AudienceRestriction audienceRestriction : audienceRestrictions) {
                     if (CollectionUtils.isNotEmpty(audienceRestriction.getAudiences())) {
                         boolean audienceFound = false;
-                        for (org.opensaml.saml2.core.Audience audience : audienceRestriction.getAudiences()) {
+                        for (org.opensaml.saml.saml2.core.Audience audience : audienceRestriction.getAudiences()) {
                             if (intendedAudience.equals(audience.getAudienceURI())) {
                                 audienceFound = true;
                                 break;
@@ -556,7 +556,7 @@ public class PassiveSTSManager {
         try {
             SAMLSignatureProfileValidator signatureProfileValidator = new SAMLSignatureProfileValidator();
             signatureProfileValidator.validate(signature);
-        } catch (ValidationException e) {
+        } catch (SignatureException e) {
             String msg = "Signature do not confirm to SAML signature profile. Possible XML Signature " +
                          "Wrapping  Attack!";
             AUDIT_LOG.warn(msg);
@@ -567,9 +567,8 @@ public class PassiveSTSManager {
         }
 
         try {
-            SignatureValidator validator = new SignatureValidator(credential);
-            validator.validate(signature);
-        } catch (ValidationException e) {
+            SignatureValidator.validate(signature, credential);
+        } catch (SignatureException e) {
             throw new PassiveSTSException("Signature validation failed for SAML Assertion", e);
         }
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.passive.sts/src/main/java/org/wso2/carbon/identity/application/authenticator/passive/sts/manager/X509CredentialImpl.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.passive.sts/src/main/java/org/wso2/carbon/identity/application/authenticator/passive/sts/manager/X509CredentialImpl.java
@@ -19,10 +19,10 @@
 package org.wso2.carbon.identity.application.authenticator.passive.sts.manager;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.opensaml.xml.security.credential.Credential;
-import org.opensaml.xml.security.credential.CredentialContextSet;
-import org.opensaml.xml.security.credential.UsageType;
-import org.opensaml.xml.security.x509.X509Credential;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.security.credential.CredentialContextSet;
+import org.opensaml.security.credential.UsageType;
+import org.opensaml.security.x509.X509Credential;
 import org.wso2.carbon.identity.application.authenticator.passive.sts.exception.PassiveSTSException;
 
 import javax.crypto.SecretKey;
@@ -81,7 +81,7 @@ public class X509CredentialImpl implements X509Credential {
     }
 
     @Override
-    public CredentialContextSet getCredentalContextSet() {
+    public CredentialContextSet getCredentialContextSet() {
         // TODO Auto-generated method stub
         return null;
     }

--- a/features/org.wso2.carbon.identity.application.authenticator.passive.sts.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.application.authenticator.passive.sts.server.feature/pom.xml
@@ -42,6 +42,16 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.opensaml</groupId>
+                    <artifactId>opensaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.opensaml</groupId>
+                    <artifactId>opensaml1</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.org.opensaml</groupId>
@@ -80,6 +90,7 @@
                                 <importFeatureDef>org.wso2.carbon.core:compatible:${carbon.kernel.feature.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.application.mgt.server:compatible:${identity.framework.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.application.authentication.framework.server:compatible:${identity.framework.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.identity.saml.common.util:${saml.common.util.version}</importFeatureDef>
                             </importFeatures>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
     </dependencyManagement>
 
     <properties>
-        <identity.framework.version>5.15.0</identity.framework.version>
+        <identity.framework.version>5.15.56-SNAPSHOT</identity.framework.version>
         <identity.framework.package.export.version>${project.version}</identity.framework.package.export.version>
 
         <javax.xml.parsers.import.pkg.version>[0.0.0, 1.0.0)</javax.xml.parsers.import.pkg.version>

--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,11 @@
                 <version>${identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.saml.common</groupId>
+                <artifactId>org.wso2.carbon.identity.saml.common.util</artifactId>
+                <version>${saml.common.util.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.orbit.org.opensaml</groupId>
                 <artifactId>opensaml</artifactId>
                 <version>${opensaml2.wso2.version}</version>
@@ -260,16 +265,16 @@
     </dependencyManagement>
 
     <properties>
-        <identity.framework.version>5.14.104-SNAPSHOT</identity.framework.version>
+        <identity.framework.version>5.15.0</identity.framework.version>
         <identity.framework.package.export.version>${project.version}</identity.framework.package.export.version>
 
         <javax.xml.parsers.import.pkg.version>[0.0.0, 1.0.0)</javax.xml.parsers.import.pkg.version>
         <opensaml2.wso2.version>3.3.1.wso2v1</opensaml2.wso2.version>
-        <opensaml2.wso2.osgi.version.range>[3.3.1,4.0.0)</opensaml2.wso2.osgi.version.range>
+        <opensaml2.wso2.osgi.version.range>[3.3.1,3.4.0)</opensaml2.wso2.osgi.version.range>
         <joda.version>2.8.2</joda.version>
         <joda.wso2.version>2.8.2.wso2v1</joda.wso2.version>
         <joda.wso2.osgi.version.range>[2.8.2,3.0.0)</joda.wso2.osgi.version.range>
-        <carbon.identity.package.import.version.range>[5.14.67, 6.0.0)</carbon.identity.package.import.version.range>
+        <carbon.identity.package.import.version.range>[5.15.0, 6.0.0)</carbon.identity.package.import.version.range>
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
@@ -278,6 +283,8 @@
         <maven.scr.plugin.version>1.7.2</maven.scr.plugin.version>
         <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>
+        <saml.common.util.version>1.0.3</saml.common.util.version>
+        <saml.common.util.version.range>[1.0.0,2.0.0)</saml.common.util.version.range>
 
         <!-- Commons -->
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -260,16 +260,16 @@
     </dependencyManagement>
 
     <properties>
-        <identity.framework.version>5.14.67</identity.framework.version>
+        <identity.framework.version>5.14.104-SNAPSHOT</identity.framework.version>
         <identity.framework.package.export.version>${project.version}</identity.framework.package.export.version>
 
         <javax.xml.parsers.import.pkg.version>[0.0.0, 1.0.0)</javax.xml.parsers.import.pkg.version>
-        <opensaml2.wso2.version>2.6.6.wso2v3</opensaml2.wso2.version>
-        <opensaml2.wso2.osgi.version.range>[2.6.0,3.0.0)</opensaml2.wso2.osgi.version.range>
+        <opensaml2.wso2.version>3.3.1.wso2v1</opensaml2.wso2.version>
+        <opensaml2.wso2.osgi.version.range>[3.3.1,4.0.0)</opensaml2.wso2.osgi.version.range>
         <joda.version>2.8.2</joda.version>
         <joda.wso2.version>2.8.2.wso2v1</joda.wso2.version>
         <joda.wso2.osgi.version.range>[2.8.2,3.0.0)</joda.wso2.osgi.version.range>
-        <carbon.identity.package.import.version.range>[5.14.0, 6.0.0)</carbon.identity.package.import.version.range>
+        <carbon.identity.package.import.version.range>[5.14.67, 6.0.0)</carbon.identity.package.import.version.range>
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>

--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
     </dependencyManagement>
 
     <properties>
-        <identity.framework.version>5.15.56-SNAPSHOT</identity.framework.version>
+        <identity.framework.version>5.15.62</identity.framework.version>
         <identity.framework.package.export.version>${project.version}</identity.framework.package.export.version>
 
         <javax.xml.parsers.import.pkg.version>[0.0.0, 1.0.0)</javax.xml.parsers.import.pkg.version>


### PR DESCRIPTION
### Proposed changes in this pull request
- Migration from OpenSAML 2.x to OpenSAML 3.x

### Prerequisites
- https://github.com/wso2/wso2-wss4j/pull/80 - wss4j with embedded OpenSAML2 dependencies.
- https://github.com/wso2/wso2-rampart/pull/101 - rampart with embedded OpenSAML2 dependencies.
- https://github.com/wso2/carbon-identity-framework/pull/2632 - identity framework with conflicting OpenSAML2 dependencies removed.

Fixes: wso2/product-is#7156